### PR TITLE
Add Permissions Policy reports

### DIFF
--- a/site/pages/index.php
+++ b/site/pages/index.php
@@ -44,6 +44,7 @@ if (\Can\Has\who() !== null) {
 	<li><a href="intervention">Intervention</a></li>
 	<li><a href="nel">Network Error Logging</a></li>
 	<li><a href="expect-ct">Expect-CT</a></li>
+	<li><a href="permissions-policy">Permissions Policy</a></li>
 </ol>
 
 <h3>Removed Browser Reporting</h3>

--- a/site/pages/index.php
+++ b/site/pages/index.php
@@ -45,6 +45,7 @@ if (\Can\Has\who() !== null) {
 	<li><a href="nel">Network Error Logging</a></li>
 	<li><a href="expect-ct">Expect-CT</a></li>
 	<li><a href="permissions-policy">Permissions Policy</a></li>
+	<li><a href="permissions-policy-report-only">Permissions Policy Report-Only</a></li>
 </ol>
 
 <h3>Removed Browser Reporting</h3>

--- a/site/pages/permissions-policy-report-only.php
+++ b/site/pages/permissions-policy-report-only.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types = 1);
+
+$reportToHeader = \Can\Has\reportToHeader();
+$permissionsPolicyHeader = 'Permissions-Policy-Report-Only: fullscreen=()';
+header($reportToHeader);
+header($permissionsPolicyHeader);
+
+echo \Can\Has\pageHead('Permissions Policy Report-Only');
+?>
+<body>
+<?= \Can\Has\headerHtml('Reporting API Demos'); ?>
+<div>
+	<?= \Can\Has\bookmarks('index', 'reports'); ?>
+
+	<h1>Permissions Policy report-only reports</h1>
+	<p><em>
+		All Permission Policy features <a href="permissions-policy#supported-features">supported</a> by your browser will function as usual, without any restrictions.
+		If the policy would be violated, a report will be sent (with <code>"disposition": "report"</code> rather than <code>"disposition": "enforce"</code>).
+		This is useful if you want to add a new policy or change the existing one, to see what would break, if you enforced the policy with <code>Permissions-Policy</code> header.
+	</em></p>
+	<p><em>
+		Permissions Policy allows web developers to selectively enable, disable, and modify the behavior of certain APIs and web features in the browser,
+			and query the state (allowed or denied) in the current document for a given feature. See the <a href="permissions-policy">Permissions Policy</a> page for more details.
+	</em></p>
+	<p><em><?= \Can\Has\permissionsPolicyBehindFlagHtml(); ?></em></p>
+	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
+	<?= \Can\Has\permissionsPolicyNotSupportedHtml() ?>
+	<h2>The <code>Permissions-Policy-Report-Only</code> response header:</h2>
+	<pre><code class="json"><?= \Can\Has\highlight($permissionsPolicyHeader); ?></code></pre>
+	<ul>
+		<li>
+			<code>fullscreen</code>: which origins can switch to full screen view
+			<ul>
+				<li><em>empty</em>: no sites, not even iframes can go full screen</li>
+			</ul>
+		</li>
+	</ul>
+
+	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+
+	<h2>Go full screen</h2>
+	<button id="fullscreen" class="allowed">Toggle full screen</button>
+	<?php \Can\Has\scriptSourceHtmlStart('allowed'); ?>
+	<script>
+		document.getElementById('fullscreen').onclick = function() {
+			if (!document.fullscreenElement) {
+				document.getElementsByTagName('html')[0].requestFullscreen()
+					.catch(function (error) {
+						alert(error.message);
+					});
+			} else {
+				document.exitFullscreen()
+					.catch(function (error) {
+						alert(error.message);
+					});
+			}
+		}
+	</script>
+	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
+	<ul>
+		<li><span class="allowed">Allowed</span> even though the current policy contains <code>fullscreen=()</code></li>
+		<li>Going full screen would be blocked if the policy was <em>enforced</em> and not <em>report-only</em></li>
+		<li><?= \Can\Has\enableExperimentalFeaturesHtml(); ?></li>
+		<li><?= \Can\Has\willTriggerReportToHtml('no violation'); ?></li>
+		<li><?= \Can\Has\checkReportsReportToHtml(); ?></li>
+	</ul>
+
+	<?= \Can\Has\specsHtml('permissions-policy', 'reporting-api'); ?>
+</div>
+<?= \Can\Has\footerHtml(); ?>
+</body>

--- a/site/pages/permissions-policy.php
+++ b/site/pages/permissions-policy.php
@@ -69,7 +69,7 @@ echo \Can\Has\pageHead('Permissions Policy');
 	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
 	<ul>
 		<li><span class="blocked">Blocked</span> by the current policy <code>geolocation=()</code>, the feature is disabled in all contexts everywhere, in all frames</li>
-		<li>The report will be sent only when the <code>chrome://flags/#enable-experimental-web-platform-features</code> flag is enabled</li>
+		<li><?= \Can\Has\enableExperimentalFeaturesHtml(); ?></li>
 		<li><?= \Can\Has\willTriggerReportToHtml('no violation'); ?></li>
 		<li><?= \Can\Has\checkReportsReportToHtml(); ?></li>
 	</ul>
@@ -87,7 +87,7 @@ echo \Can\Has\pageHead('Permissions Policy');
 	<iframe src="https://www.youtube-nocookie.com/embed/twqSIvSPQW0" frameborder="0" allow="fullscreen"></iframe>
 	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
 
-	<h2>List of all features supported by your browser</h2>
+	<h2 id="supported-features">List of all features supported by your browser</h2>
 	<ul id="features">
 	</ul>
 	<script>

--- a/site/pages/permissions-policy.php
+++ b/site/pages/permissions-policy.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types = 1);
+
+$reportToHeader = \Can\Has\reportToHeader();
+$permissionsPolicyHeader = 'Permissions-Policy: geolocation=(), fullscreen=(self "https://www.michalspacek.cz")';
+header($reportToHeader);
+header($permissionsPolicyHeader);
+
+echo \Can\Has\pageHead('Permissions Policy');
+?>
+<body>
+<?= \Can\Has\headerHtml('Reporting API Demos'); ?>
+<div>
+	<?= \Can\Has\bookmarks('index', 'reports'); ?>
+
+	<h1>Permissions Policy reports</h1>
+	<p><em>
+		Permissions Policy allows web developers to selectively enable, disable, and modify the behavior of certain APIs and web features in the browser,
+			and query the state (allowed or denied) in the current document for a given feature.
+		The policies control what the browser can do and are inherited by all iframes on the page that has set the policy.
+		That means for example that no iframe embedded in your page can go fullscreen, unless explicitly enabled, if your page has disallowed going fullscreen.
+	</em></p>
+	<p><em>
+		The <code>Permissions-Policy</code> header is similar to Content Security Policy header, although the syntax is different
+			as the <code>Permissions-Policy</code> header is defined as a <a href="https://datatracker.ietf.org/doc/html/rfc8941">Structured Header</a>.
+		Permissions Policy, shipped in Chrome 88, was previously known as Feature Policy and was available in Chrome since 2016. Both Permissions Policy and Feature Policy share the same ideas
+			but the <code>Feature-Policy</code> header used a <a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#new-header">different format</a>
+			and treated iframe <code>allow</code> attribute <a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#header-and-allow-attribute-combine-differently">differently</a>.
+		The migration is not fully finished yet and the old name still has to be used in scripts.
+	</em></p>
+	<p><em><?= \Can\Has\permissionsPolicyBehindFlagHtml(); ?></em></p>
+	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
+	<?= \Can\Has\permissionsPolicyNotSupportedHtml() ?>
+	<h2>The <code>Permissions-Policy</code> response header:</h2>
+	<pre><code class="json"><?= \Can\Has\highlight($permissionsPolicyHeader); ?></code></pre>
+	<ul>
+		<li>
+			<code>geolocation</code>: which origins can get the current location of the user's device
+			<ul>
+				<li><em>empty</em>: no sites, not even iframes can query the location</li>
+			</ul>
+		</li>
+		<li>
+			<code>fullscreen</code>: which origins can go fullscreen
+			<ul>
+				<li><code>self</code>: current origin (scheme + host + port)</li>
+				<li><code>"https://www.michalspacek.cz"</code>: or anything embedded in an iframe loaded from my site but not an embedded YouTube video for example</li>
+			</ul>
+		</li>
+	</ul>
+
+	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+
+	<h2>Try getting the current location of the device</h2>
+	<button id="geolocation" class="blocked">Get current geolocation</button>
+	<?php \Can\Has\scriptSourceHtmlStart('blocked'); ?>
+	<script>
+		document.getElementById('geolocation').onclick = function() {
+			navigator.geolocation.getCurrentPosition(
+				function (position) {
+					alert('Your current position is:\nLatitude: ' + position.coords.latitude + '\nLongitude: ' + position.coords.longitude + '\n± ' + position.coords.accuracy + ' meters');
+				},
+				function (error) {
+					alert(error.message);
+				}
+			);
+		}
+	</script>
+	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
+	<ul>
+		<li><span class="blocked">Blocked</span> by the current policy <code>geolocation=()</code>, the feature is disabled in all contexts everywhere, in all frames</li>
+		<li>The report will be sent only when the <code>chrome://flags/#enable-experimental-web-platform-features</code> flag is enabled</li>
+		<li><?= \Can\Has\willTriggerReportToHtml('no violation'); ?></li>
+		<li><?= \Can\Has\checkReportsReportToHtml(); ?></li>
+	</ul>
+
+	<h2>Embedded frame cannot go fullscreen</h2>
+	<?php \Can\Has\scriptSourceHtmlStart('blocked'); ?>
+	<iframe src="https://www.youtube-nocookie.com/embed/twqSIvSPQW0" frameborder="0"></iframe>
+	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
+	<ul>
+		<li>Fullscreen <span class="blocked">blocked</span> by the current <code>fullscreen</code> policy</li>
+	</ul>
+
+	<p>Fullscreen and other <em>features</em> can be allowed on a per-iframe basis with an <code>allow</code> attribute provided the <code>Permissions-Policy</code> header also contains the origin:</p>
+	<?php \Can\Has\scriptSourceHtmlStart('allowed'); ?>
+	<iframe src="https://www.youtube-nocookie.com/embed/twqSIvSPQW0" frameborder="0" allow="fullscreen"></iframe>
+	<?php \Can\Has\scriptSourceHtmlEnd(); ?>
+
+	<h2>List of all features supported by your browser</h2>
+	<ul id="features">
+	</ul>
+	<script>
+		const features = document.getElementById('features');
+		const policy = document.permissionsPolicy ?? document.featurePolicy;
+		if (typeof policy === 'undefined') {
+			const li = document.createElement('li');
+			li.innerText = 'none'
+			features.appendChild(li);
+		} else {
+			policy.features().sort().forEach(function (feature) {
+				const code = document.createElement('code')
+				code.innerText = feature;
+				const li = document.createElement('li');
+				li.appendChild(code)
+				features.appendChild(li);
+			})
+			const counting = document.createElement('a');
+			counting.href = 'https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md';
+			counting.innerText = 'counting';
+			const li = document.createElement('li');
+			li.innerText = '… and ';
+			li.appendChild(counting);
+			features.appendChild(li);
+		}
+	</script>
+
+	<?= \Can\Has\specsHtml('permissions-policy', 'reporting-api'); ?>
+</div>
+<?= \Can\Has\footerHtml(); ?>
+</body>

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -334,6 +334,25 @@ function trustedTypesNotSupportedHtml(string $messageSuffix = 'the demo will not
 }
 
 
+function permissionsPolicyBehindFlagHtml(): string
+{
+	return <<< 'EOT'
+		Right now, the policy violation reporting part of Permissions Policy <strong>must be manually enabled</strong> in Chrome by setting the
+			<a href="chrome://flags/#enable-experimental-web-platform-features">Experimental Web Platform features</a> flag (copy & paste the link), otherwise you'll get no reports.
+		Also, only first-party reports will be sent, no reports for violations that happened in embedded iframes.
+	EOT;
+}
+
+
+function permissionsPolicyNotSupportedHtml(string $messageSuffix = 'no reports will be sent'): string
+{
+	return '<div class="permissions-policy not-supported hidden">'
+		. '🍌 Your browser <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#browser_compatibility">does not</a> support Permissions Policy</a>, '
+		. $messageSuffix
+		. '</div>';
+}
+
+
 function scriptSourceHtmlStart(string $class): bool
 {
 	static $counter = 0;
@@ -470,6 +489,15 @@ function specsHtml(string ...$specs): string
 				$hrefs[] = '<a href="https://w3c.github.io/webappsec-trusted-types/dist/spec/">Trusted Types</a> Editor\'s Draft';
 				$hrefs[] = '<a href="https://web.dev/trusted-types/">Prevent DOM-based cross-site scripting vulnerabilities with Trusted Types</a> on web.dev';
 				$hrefs[] = '<a href="https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API">Trusted Types API</a> on MDN';
+				break;
+			case 'permissions-policy':
+				$hrefs[] = <<< 'EOT'
+					<a href="https://www.w3.org/TR/permissions-policy/">Permissions Policy</a> Working Draft
+					<ul>
+						<li><small><a href="https://w3c.github.io/webappsec-permissions-policy/">Permissions Policy</a> Editor's Draft</small></li>
+					</ul>
+				EOT;
+				$hrefs[] = '<a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md">Permissions Policy explainer</a>';
 				break;
 		}
 	}

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -334,6 +334,12 @@ function trustedTypesNotSupportedHtml(string $messageSuffix = 'the demo will not
 }
 
 
+function enableExperimentalFeaturesHtml(): string
+{
+	return 'The report will be sent only when the <code>chrome://flags/#enable-experimental-web-platform-features</code> flag is enabled';
+}
+
+
 function permissionsPolicyBehindFlagHtml(): string
 {
 	return <<< 'EOT'

--- a/site/www/assets/scripts.js
+++ b/site/www/assets/scripts.js
@@ -26,6 +26,9 @@
 	if (!window.trustedTypes) {
 		showElements('trusted-types not-supported');
 	}
+	if (typeof (document.permissionsPolicy ?? document.featurePolicy) === 'undefined') {
+		showElements('permissions-policy not-supported');
+	}
 })();
 document.addEventListener('DOMContentLoaded', function () {
 	const list = document.getElementsByClassName('view-source');


### PR DESCRIPTION
This adds a ~~Feature Policy~~ Permissions Policy (and Permissions Policy Report-Only) reports page.

Can be merged once browsers will generally send reports, right now it's just an Origin Trial in Chrome, see https://www.chromestatus.com/feature/6294138899136512 But be careful that the thing and the header has been renamed in the current Editor's draft to *Permissions policy* https://github.com/w3c/webappsec-feature-policy/issues/359 so this PR will need more love.

No GA support for `Feature-Policy-Report-Only` either as of now.