### PR TITLE
Query string support & `fbclid` removal

### DIFF
--- a/site/www/app.php
+++ b/site/www/app.php
@@ -5,7 +5,8 @@ declare(strict_types = 1);
 
 require __DIR__ . '/../shared/functions.php';
 
-$pathinfo = pathinfo($_SERVER['REQUEST_URI'] === '/' ? '/index' : $_SERVER['REQUEST_URI']);
+$requestUri = preg_replace('~\?.*$~', '', $_SERVER['REQUEST_URI']);
+$pathinfo = pathinfo($requestUri === '/' ? '/index' : $requestUri);
 if (isset($pathinfo['extension']) && $pathinfo['extension'] === 'php') {
 	header('Location: /' . $pathinfo['filename'], true, 301);
 	echo 'Redirecting to <a href="/' . htmlspecialchars($pathinfo['filename']) . '">/' . htmlspecialchars($pathinfo['filename']) . '</a>';

--- a/site/www/assets/scripts.js
+++ b/site/www/assets/scripts.js
@@ -8,25 +8,25 @@
 			// Let'em track'em
 		}
 	}
-})();
-const showElements = function (classNames) {
-	document.addEventListener('DOMContentLoaded', function () {
-		const list = document.getElementsByClassName(classNames);
-		for (let element of list) {
-			element.classList.remove('hidden');
-		}
-	});
-}
-try {
-	new ReportingObserver(() => {});
-} catch (e) {
-	if (e instanceof ReferenceError) {
-		showElements('reporting-api not-supported');
+	const showElements = function (classNames) {
+		document.addEventListener('DOMContentLoaded', function () {
+			const list = document.getElementsByClassName(classNames);
+			for (let element of list) {
+				element.classList.remove('hidden');
+			}
+		});
 	}
-}
-if (!window.trustedTypes) {
-	showElements('trusted-types not-supported');
-}
+	try {
+		new ReportingObserver(() => {});
+	} catch (e) {
+		if (e instanceof ReferenceError) {
+			showElements('reporting-api not-supported');
+		}
+	}
+	if (!window.trustedTypes) {
+		showElements('trusted-types not-supported');
+	}
+})();
 document.addEventListener('DOMContentLoaded', function () {
 	const list = document.getElementsByClassName('view-source');
 	for (let element of list) {

--- a/site/www/assets/scripts.js
+++ b/site/www/assets/scripts.js
@@ -1,3 +1,14 @@
+(function() {
+	if (location.search.indexOf('fbclid=') !== -1) {
+		try {
+			const url = new URL(location);
+			url.searchParams.delete('fbclid');
+			history.replaceState(null, '', url.href);
+		} catch (ex) {
+			// Let'em track'em
+		}
+	}
+})();
 const showElements = function (classNames) {
 	document.addEventListener('DOMContentLoaded', function () {
 		const list = document.getElementsByClassName(classNames);


### PR DESCRIPTION
Support query string but don't use it for loading pages

Remove, rather hide `fbclid` param if present in the URL.