### PR TITLE
Make the nonce have no trailing `==`

### DIFF
--- a/site/pages/csp-report-to.php
+++ b/site/pages/csp-report-to.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-$nonce = base64_encode(random_bytes(16));
+$nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; report-to default";
 $pageHeaderHtml = 'Content Security Policy with <code>report-to</code>';
 $reportToHeader = \Can\Has\reportToHeader();

--- a/site/pages/csp-report-uri.php
+++ b/site/pages/csp-report-uri.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-$nonce = base64_encode(random_bytes(16));
+$nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; report-uri " . \Can\Has\reportUrl('csp/enforce');
 $pageHeaderHtml = 'Content Security Policy with <code>report-uri</code>';
 $pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports.<br><br>

--- a/site/pages/csp-urls.php
+++ b/site/pages/csp-urls.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-$nonce = base64_encode(random_bytes(16));
+$nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; form-action 'self'; report-to default";
 $reportToHeader = \Can\Has\reportToHeader();
 header($cspHeader);

--- a/site/pages/cspro-report-to.php
+++ b/site/pages/cspro-report-to.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-$nonce = base64_encode(random_bytes(16));
+$nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy-Report-Only: default-src data: 'self' 'nonce-{$nonce}' 'report-sample'; report-to default";
 $reportToHeader = \Can\Has\reportToHeader();
 header($cspHeader);

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -405,6 +405,12 @@ function dataRetentionDays(): int
 }
 
 
+function randomNonce(): string
+{
+	return base64_encode(random_bytes(16));
+}
+
+
 function specsHtml(string ...$specs): string
 {
 	$hrefs = [];

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -407,7 +407,7 @@ function dataRetentionDays(): int
 
 function randomNonce(): string
 {
-	return base64_encode(random_bytes(16));
+	return base64_encode(random_bytes(18));
 }
 
 


### PR DESCRIPTION
Which means that the highlighter won't find any "attributes", and even the Base64-encoded nonce length is the same.

Fix #11