### PR TITLE
Move Very Critical CSS to HTML to fix Google's Mobile Usability warnings

### DIFF
--- a/site/pages/csp-report-to.php
+++ b/site/pages/csp-report-to.php
@@ -2,7 +2,7 @@
 declare(strict_types = 1);
 
 $nonce = \Can\Has\randomNonce();
-$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; report-to default";
+$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; report-to default";
 $pageHeaderHtml = 'Content Security Policy with <code>report-to</code>';
 $reportToHeader = \Can\Has\reportToHeader();
 $pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports with Reporting API using the <code>Report-To</code> header, asynchronously and out-of-band, when the browser feels like, possibly grouped with other reports and even other report types.<br><br>
@@ -25,7 +25,7 @@ header($reportToHeader);
 <!DOCTYPE html>
 <html lang="en">
 <?php
-echo \Can\Has\pageHead('CSP report-to');
+echo \Can\Has\pageHead('CSP report-to', $nonce);
 require __DIR__ . '/../shared/csp-body.php';
 ?>
 </html>

--- a/site/pages/csp-report-uri.php
+++ b/site/pages/csp-report-uri.php
@@ -2,7 +2,7 @@
 declare(strict_types = 1);
 
 $nonce = \Can\Has\randomNonce();
-$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; report-uri " . \Can\Has\reportUrl('csp/enforce');
+$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; report-uri " . \Can\Has\reportUrl('csp/enforce');
 $pageHeaderHtml = 'Content Security Policy with <code>report-uri</code>';
 $pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports.<br><br>
 	CSP is a policy that lets the authors (or server administrators) of a web application inform the browser about the sources from which the application expects to load resources like images, scripts, styles, or even where to submit forms.
@@ -23,7 +23,7 @@ header($cspHeader);
 <!DOCTYPE html>
 <html lang="en">
 <?php
-echo \Can\Has\pageHead('CSP report-uri');
+echo \Can\Has\pageHead('CSP report-uri', $nonce);
 require __DIR__ . '/../shared/csp-body.php';
 ?>
 </html>

--- a/site/pages/csp-urls.php
+++ b/site/pages/csp-urls.php
@@ -2,14 +2,14 @@
 declare(strict_types = 1);
 
 $nonce = \Can\Has\randomNonce();
-$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self'; form-action 'self'; report-to default";
+$cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; form-action 'self'; report-to default";
 $reportToHeader = \Can\Has\reportToHeader();
 header($cspHeader);
 header($reportToHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
-<?= \Can\Has\pageHead('More CSP reports'); ?>
+<?= \Can\Has\pageHead('More CSP reports', $nonce); ?>
 <body>
 <?= \Can\Has\headerHtml('Reporting API Demos'); ?>
 <div id="main">

--- a/site/pages/cspro-report-to.php
+++ b/site/pages/cspro-report-to.php
@@ -9,7 +9,7 @@ header($reportToHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
-<?= \Can\Has\pageHead('CSPRO report-to'); ?>
+<?= \Can\Has\pageHead('CSPRO report-to', $nonce); ?>
 <body>
 <?= \Can\Has\headerHtml('Browser Reporting Demos'); ?>
 <div id="main">
@@ -30,7 +30,7 @@ header($reportToHeader);
 			<ul>
 				<li><code>data:</code> used for the placeholder image below</li>
 				<li><code>'self'</code> means current URL's origin (scheme + host + port)</li>
-				<li><code>'nonce-<?= htmlspecialchars($nonce); ?>'</code> means <code>script</code> elements with <code>nonce="<?= htmlspecialchars($nonce); ?>"</code> attribute</li>
+				<li><code>'nonce-<?= htmlspecialchars($nonce); ?>'</code> means <code>script</code> & <code>style</code> elements with <code>nonce="<?= htmlspecialchars($nonce); ?>"</code> attribute</li>
 				<li>
 					<code>'report-sample'</code> instructs the browser to include a violation sample, the first 40 characters
 					(valid for CSS, JS only but included in <code>default-src</code> here to keep the header short)

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -20,11 +20,16 @@ function bookmarks(string ...$links): string
 }
 
 
-function pageHead(?string $title = null): string
+function pageHead(?string $title = null, ?string $nonce = null): string
 {
 	return '<head>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>' . ($title ? " {$title} | " : '') . 'Reporting API Demos</title>
+		<style' . ($nonce ? ' nonce="' . \htmlspecialchars($nonce) . '"' : '') . '>
+			body { font: 1em/1.5 Arial, sans-serif; }
+			img { max-width: 100%; height: auto; }
+			pre { overflow-x: auto; }
+		</style>
 		<link rel="icon" type="image/svg+xml" href="' . \htmlspecialchars(baseOrigin()) . '/assets/favicon.svg">
 		<link rel="alternate icon" href="' . \htmlspecialchars(baseOrigin()) . '/assets/favicon.png">
 		<link rel="stylesheet" href="' . \htmlspecialchars(baseOrigin()) . '/assets/style.css">


### PR DESCRIPTION
Warnings like:

- Content wider than screen
- Text too small to read
- Clickable elements too close together

Why it probably happens see https://support.google.com/webmasters/thread/63865816/google-bot-wont-fetch-my-css-and-font-files-mobile-friendly-errore-in-gsc?hl=en

This is the same thing I've done in https://github.com/spaze/michalspacek.cz/commit/3d5e1e1cb9f755472453fab182de9afc89d633b1