### PR TITLE
Reporting API v1 Reporting-Endpoints

### DIFF
--- a/site/pages/crash.php
+++ b/site/pages/crash.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
-header($reportToHeader);
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -13,10 +13,10 @@ header($reportToHeader);
 <div class="content">
 	<?= \Can\Has\bookmarks('index', 'reports'); ?>
 	<h1>Crash reports with <code>report-to</code></h1>
-	<p><em>Sending reports about browser or tab (where tab means one of the browser processes) crashes with Reporting API using the <code>Report-To</code> header (and only the <code>Report-To</code> header, no other header required), asynchronously.</em></p>
+	<p><em>Sending reports about browser or tab (where tab means one of the browser processes) crashes with Reporting API using the <code>Reporting-Endpoints</code> header (and only the <code>Reporting-Endpoints</code> header, no other header required), asynchronously.</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
 
 	<h2>Try crashing your tab</h2>
 	<p>
@@ -24,7 +24,7 @@ header($reportToHeader);
 	</p>
 	<ul>
 		<li><?= \Can\Has\willTriggerReportToHtml(); ?></li>
-		<li>&hellip;if the tab crashes in <code>max_age</code> seconds after receiving the <code>Report-To</code> header, <a href="crash">reload</a> the page first to make sure it does (you'll want to use bigger <code>max_age</code> in your real header)</li>
+		<li>&hellip;if the tab crashes after receiving the <code>Reporting-Endpoints</code> header, <a href="crash">reload</a> the page first to make sure it does</li>
 		<li><?= \Can\Has\checkReportsReportToHtml(); ?></li>
 		<li>Reports can contain an optional <code>reason</code>, e.g. <code>oom</code> (Out-of-Memory, try with <a href="chrome://memory-exhaust/">chrome://memory-exhaust/</a>), <code>unresponsive</code> (killed due to being unresponsive)</li>
 	</ul>

--- a/site/pages/crash.php
+++ b/site/pages/crash.php
@@ -16,7 +16,7 @@ header($reportingEndpointsHeader);
 	<p><em>Sending reports about browser or tab (where tab means one of the browser processes) crashes with Reporting API using the <code>Reporting-Endpoints</code> header (and only the <code>Reporting-Endpoints</code> header, no other header required), asynchronously.</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'crash reports are delivered to an endpoint named <code>crash-reporting</code> if specified, otherwise to an endpoint named <code>default</code>'); ?>
 
 	<h2>Try crashing your tab</h2>
 	<p>

--- a/site/pages/crash.php
+++ b/site/pages/crash.php
@@ -29,7 +29,7 @@ header($reportingEndpointsHeader);
 		<li>Reports can contain an optional <code>reason</code>, e.g. <code>oom</code> (Out-of-Memory, try with <a href="chrome://memory-exhaust/">chrome://memory-exhaust/</a>), <code>unresponsive</code> (killed due to being unresponsive)</li>
 	</ul>
 
-	<?= \Can\Has\specsHtml('reporting-api'); ?>
+	<?= \Can\Has\specsHtml('reporting-api', 'crash'); ?>
 </div>
 </div>
 <?= \Can\Has\footerHtml(); ?>

--- a/site/pages/csp-report-to.php
+++ b/site/pages/csp-report-to.php
@@ -4,23 +4,22 @@ declare(strict_types = 1);
 $nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; report-to default";
 $pageHeaderHtml = 'Content Security Policy with <code>report-to</code>';
-$reportToHeader = \Can\Has\reportToHeader();
-$pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports with Reporting API using the <code>Report-To</code> header, asynchronously and out-of-band, when the browser feels like, possibly grouped with other reports and even other report types.<br><br>
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
+$pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports with Reporting API using the <code>Reporting-Endpoints</code> header, asynchronously and out-of-band, when the browser feels like, possibly grouped with other reports and even other report types.<br><br>
 	CSP is a policy that lets the authors (or server administrators) of a web application inform the browser about the sources from which the application expects to load resources like images, scripts, styles, or even where to submit forms.
 	Content Security Policy is not intended as a first line of defense against content injection vulnerabilities like Cross-Site Scripting (XSS). Instead, CSP is best used as defense-in-depth, to reduce the harm caused by content injection attacks.
 	The <code>report-to</code> directive using the Reporting API replaces the deprecated <code>report-uri</code> directive in Content Security Policy level 3 spec, which is not yet fully supported by all major clients.
 	To support more browsers, apps usually send both <code>report-uri</code> and <code>report-to</code> in their CSP headers.';
 $includeReportingApiNotSupportedWarning = true;
 $cspHeaderDescription = 'The CSP response header';
-$reportDirective = 'report-to';
-$reportDirectiveDescription = 'name of the group where to send violation reports to';
+$reportDirectiveDescriptionHtml = \Can\Has\reportToDirectiveDescriptionHtml();
 $willTriggerReportHtml = \Can\Has\willTriggerReportToHtml();
 $checkReportsHtml = \Can\Has\checkReportsReportToHtml();
-$additionalHeaderHtml = \Can\Has\reportToHeaderHtml($reportToHeader, 'the same as in the CSP header in the <code>report-to</code> directive');
+$additionalHeaderHtml = \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the same as in the CSP header in the <code>report-to</code> directive');
 $specs = ['csp', 'reporting-api'];
 
 header($cspHeader);
-header($reportToHeader);
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/site/pages/csp-report-to.php
+++ b/site/pages/csp-report-to.php
@@ -5,7 +5,7 @@ $nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; report-to default";
 $pageHeaderHtml = 'Content Security Policy with <code>report-to</code>';
 $reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
-$pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports with Reporting API using the <code>Reporting-Endpoints</code> header, asynchronously and out-of-band, when the browser feels like, possibly grouped with other reports and even other report types.<br><br>
+$pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports with Reporting API using the <code>Reporting-Endpoints</code> header, asynchronously and out-of-band, when the browser feels like.<br><br>
 	CSP is a policy that lets the authors (or server administrators) of a web application inform the browser about the sources from which the application expects to load resources like images, scripts, styles, or even where to submit forms.
 	Content Security Policy is not intended as a first line of defense against content injection vulnerabilities like Cross-Site Scripting (XSS). Instead, CSP is best used as defense-in-depth, to reduce the harm caused by content injection attacks.
 	The <code>report-to</code> directive using the Reporting API replaces the deprecated <code>report-uri</code> directive in Content Security Policy level 3 spec, which is not yet fully supported by all major clients.

--- a/site/pages/csp-report-uri.php
+++ b/site/pages/csp-report-uri.php
@@ -11,8 +11,7 @@ $pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports.
 	To support more browsers, apps usually send both <code>report-uri</code> and <code>report-to</code> in their CSP headers.';
 $includeReportingApiNotSupportedWarning = false;
 $cspHeaderDescription = 'The CSP response header';
-$reportDirective = 'report-uri';
-$reportDirectiveDescription = 'where to send violation reports to';
+$reportDirectiveDescriptionHtml = '<code>report-uri</code>: where to send violation reports to';
 $willTriggerReportHtml = \Can\Has\willTriggerReportUriHtml();
 $checkReportsHtml = \Can\Has\checkReportsReportUriHtml();
 $additionalHeaderHtml = null;

--- a/site/pages/csp-report-uri.php
+++ b/site/pages/csp-report-uri.php
@@ -11,7 +11,7 @@ $pageDescriptionHtml = 'Sending Content Security Policy (CSP) violation reports.
 	To support more browsers, apps usually send both <code>report-uri</code> and <code>report-to</code> in their CSP headers.';
 $includeReportingApiNotSupportedWarning = false;
 $cspHeaderDescription = 'The CSP response header';
-$reportDirectiveDescriptionHtml = '<code>report-uri</code>: where to send violation reports to';
+$reportDirectiveDescriptionHtml = '<code>report-uri</code>: where to send violation reports';
 $willTriggerReportHtml = \Can\Has\willTriggerReportUriHtml();
 $checkReportsHtml = \Can\Has\checkReportsReportUriHtml();
 $additionalHeaderHtml = null;

--- a/site/pages/csp-urls.php
+++ b/site/pages/csp-urls.php
@@ -16,7 +16,7 @@ header($reportingEndpointsHeader);
 <div class="content">
 	<?= \Can\Has\bookmarks('index', 'reports'); ?>
 	<h1>More Content Security Policy with <code>report-to</code></h1>
-	<p><em>Sending even more Content Security Policy (CSP) violation reports with <code>report-to</code>, asynchronously and possibly grouping more reports together. Read <a href="csp-report-to">general CSP reporting</a> description for more details.</em></p>
+	<p><em>Sending even more Content Security Policy (CSP) violation reports with <code>report-to</code>, asynchronously. Read <a href="csp-report-to">general CSP reporting</a> description for more details.</em></p>
 
 	<h2>The CSP response header:</h2>
 	<pre><code><?= \Can\Has\highlight($cspHeader); ?></code></pre>

--- a/site/pages/csp-urls.php
+++ b/site/pages/csp-urls.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 $nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy: default-src 'none'; img-src 'self' https://www.michalspacek.cz; script-src 'nonce-{$nonce}' 'self' 'report-sample'; style-src 'self' 'nonce-{$nonce}'; form-action 'self'; report-to default";
-$reportToHeader = \Can\Has\reportToHeader();
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
 header($cspHeader);
-header($reportToHeader);
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -37,10 +37,10 @@ header($reportToHeader);
 		</li>
 		<li><code>style-src</code>: allowed CSS sources</li>
 		<li><code>form-action</code>: where it's allowed to submit forms, not part of <code>default-src</code></li>
-		<li><code>report-to</code>: name of the group where to send violation reports to</li>
+		<li><?= \Can\Has\reportToDirectiveDescriptionHtml(); ?></li>
 	</ul>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the same as in the CSP header in the <code>report-to</code> directive'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the same as in the CSP header in the <code>report-to</code> directive'); ?>
 
 	<h2>Load any image</h2>
 	<p>

--- a/site/pages/cspro-report-to.php
+++ b/site/pages/cspro-report-to.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 $nonce = \Can\Has\randomNonce();
 $cspHeader = "Content-Security-Policy-Report-Only: default-src data: 'self' 'nonce-{$nonce}' 'report-sample'; report-to default";
-$reportToHeader = \Can\Has\reportToHeader();
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
 header($cspHeader);
-header($reportToHeader);
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -37,10 +37,10 @@ header($reportToHeader);
 				</li>
 			</ul>
 		</li>
-		<li><code>report-to</code>: name of the group where to send violation reports to</li>
+		<li><?= \Can\Has\reportToDirectiveDescriptionHtml(); ?></li>
 	</ul>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the same as in the CSP header in the <code>report-to</code> directive'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the same as in the CSP header in the <code>report-to</code> directive'); ?>
 
 	<h2>Try it with images</h2>
 	<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABDAQMAAABQhTKZAAAABlBMVEX////MzMw46qqDAAAAI0lEQVR4AWP4f4D/D4xgGGAeg/0H5v8wYmB5gytcRsNlNFwAFna2DZiUiFYAAAAASUVORK5CYII=" id="image" width="100" height="67" alt="Loaded image">

--- a/site/pages/cspro-report-uri.php
+++ b/site/pages/cspro-report-uri.php
@@ -29,7 +29,7 @@ header($cspHeader);
 				<li><code>'unsafe-inline'</code> means JavaScript, CSS inlined right in the HTML source code, not in external files (e.g. code between <code>&lt;script&gt;</code> and <code>&lt;/script&gt;</code>, handlers like <code>onmouseover</code> etc.)</li>
 			</ul>
 		</li>
-		<li><code>report-uri</code>: where to send violation reports to</li>
+		<li><code>report-uri</code>: where to send violation reports</li>
 	</ul>
 
 	<h2>Image mixed content</h2>

--- a/site/pages/deprecation.php
+++ b/site/pages/deprecation.php
@@ -21,7 +21,7 @@ header($reportingEndpointsHeader);
 	</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'deprecation reports are always delivered to the endpoint named <code>default</code>'); ?>
 
 	<h2>Use a deprecated feature</h2>
 	<p>

--- a/site/pages/deprecation.php
+++ b/site/pages/deprecation.php
@@ -65,7 +65,7 @@ header($reportingEndpointsHeader);
 	</ul>
 	<p>See Chrome's <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/deprecation/deprecation.json5;l=63">source code</a> for more deprecated and invalid features.</p>
 
-	<?= \Can\Has\specsHtml('reporting-api'); ?>
+	<?= \Can\Has\specsHtml('reporting-api', 'deprecation'); ?>
 </div>
 </div>
 <?= \Can\Has\footerHtml(); ?>

--- a/site/pages/deprecation.php
+++ b/site/pages/deprecation.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
-header($reportToHeader);
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -16,11 +16,12 @@ header($reportToHeader);
 	<h1>Deprecation reports</h1>
 	<p><em>
 		Some browser features, functions, or APIs are considered <em>deprecated</em>, no longer recommended, and while they still work, you shouldn't be using them.
-		Deprecation reporting will send you a report if your code uses such deprecated feature, all you need to send is a <code>Report-To</code> response header.
+		Deprecation reporting will send you a report if your code uses such deprecated feature, all you need to send is a <code>Reporting-Endpoints</code> response header.
+		Deprecation reports are always delivered to the endpoint named <code>default</code>.
 	</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
 
 	<h2>Use a deprecated feature</h2>
 	<p>

--- a/site/pages/dmarc.php
+++ b/site/pages/dmarc.php
@@ -22,8 +22,8 @@ declare(strict_types = 1);
 	<ul>
 		<li><code>v=DMARC1</code>: this TXT DNS record is a DMARC policy record</li>
 		<li><code>p=quarantine</code>: mail receivers should quarantine messages from example.com that fail authentication, usually means "place into spam folder", other policies are <code>none</code> and <code>reject</code></li>
-		<li><code>rua</code>: where to send <em>aggregated</em> reports to, can be any valid URI (multiple URIs comma-separated) but only <code>mailto:</code> is guaranteed to be universally supported</li>
-		<li><code>ruf</code>: one or more URIs where to send message-specific detailed <em>failure</em> reports to, only <code>mailto:</code> is guaranteed to be universally supported</li>
+		<li><code>rua</code>: where to send <em>aggregated</em> reports, can be any valid URI (multiple URIs comma-separated) but only <code>mailto:</code> is guaranteed to be universally supported</li>
+		<li><code>ruf</code>: one or more URIs where to send message-specific detailed <em>failure</em> reports, only <code>mailto:</code> is guaranteed to be universally supported</li>
 	</ul>
 	<p>
 		The email address in <code>rua</code> and <code>ruf</code> should be the same as the domain where the DMARC policy was found at, which is the case for the failure reports in the example above.

--- a/site/pages/expect-ct.php
+++ b/site/pages/expect-ct.php
@@ -30,7 +30,7 @@ header($expectCtHeader);
 			<code>enforce</code>: optional, if present, the browser should refuse future connections that violate the CT policy, for <code>max-age</code> seconds after the reception of the <code>Expect-CT</code> header
 			&ndash; using <code>enforce</code> doesn't make sense with <code>max-age: 0</code>, also keep in mind some browsers have their own CT requirements that cannot be disabled by simply omitting <code>enforce</code> or setting a short <code>max-age</code>
 		</li>
-		<li><code>report-uri</code>: where to send policy violation reports to, must use HTTPS</li>
+		<li><code>report-uri</code>: where to send policy violation reports, must use HTTPS</li>
 	</ul>
 
 	<h2>Test Expect-CT reporting</h2>

--- a/site/pages/index.php
+++ b/site/pages/index.php
@@ -33,13 +33,12 @@ if (\Can\Has\who() !== null) {
 	In Chrome, you can also use <a href="chrome://net-export/">chrome://net-export/</a> (copy/paste the link) to see "hidden" asynchronous reports in exported logs.
 	See my <a href="https://www.michalspacek.com/chrome-err_spdy_protocol_error-and-an-invalid-http-header">article about how to read the logs</a>.
 </p>
-<p>Not all of these use Reporting API, some are proprietary reporting mechanisms and you'll notice them easily &ndash; they don't use the <code>Report-To</code> header.</p>
 <ol>
-	<li><a href="csp-report-uri">Content Security Policy <code>report-uri</code></a></li>
-	<li><a href="csp-report-to">Content Security Policy <code>report-to</code></a></li>
+	<li><a href="csp-report-uri">Content Security Policy <code>report-uri</code> directive</a></li>
+	<li><a href="csp-report-to">Content Security Policy <code>report-to</code> directive</a></li>
 	<li><a href="csp-urls">More CSP <code>report-to</code> &ndash; load resources by specified URL, submit forms</a></li>
-	<li><a href="cspro-report-uri">CSP Report-Only <code>report-uri</code> &ndash; mixed content detection</a></li>
-	<li><a href="cspro-report-to">CSP Report-Only <code>report-to</code></a></li>
+	<li><a href="cspro-report-uri">CSP Report-Only <code>report-uri</code> directive &ndash; mixed content detection</a></li>
+	<li><a href="cspro-report-to">CSP Report-Only <code>report-to</code> directive</a></li>
 	<li><a href="crash">Crash</a></li>
 	<li><a href="deprecation">Deprecation</a></li>
 	<li><a href="intervention">Intervention</a></li>
@@ -48,6 +47,11 @@ if (\Can\Has\who() !== null) {
 	<li><a href="permissions-policy-iframes">Permissions Policy in iframes</a></li>
 	<li><a href="permissions-policy-report-only">Permissions Policy Report-Only</a></li>
 </ol>
+<p>
+	Not all of these use Reporting API, some are proprietary reporting mechanisms and you'll notice them easily &ndash; they don't use the Reporting API's <code>Reporting-Endpoints</code> header.
+	Earlier versions of the Reporting API specification used <code>Report-To</code> header instead of <code>Reporting-Endpoints</code>.
+	The <code>Report-To</code> header is deprecated and should not be confused with the CSP <code>report-to</code> directive.
+</p>
 
 <h3>Removed Browser Reporting</h3>
 <p>Browsers used to send some reports but don't anymore as these features have been (mostly) removed:</p>

--- a/site/pages/index.php
+++ b/site/pages/index.php
@@ -42,7 +42,7 @@ if (\Can\Has\who() !== null) {
 	<li><a href="crash">Crash</a></li>
 	<li><a href="deprecation">Deprecation</a></li>
 	<li><a href="intervention">Intervention</a></li>
-	<li><a href="nel">Network Error Logging</a></li>
+	<li><a href="nel">Network Error Logging (NEL)</a></li>
 	<li><a href="permissions-policy">Permissions Policy</a></li>
 	<li><a href="permissions-policy-iframes">Permissions Policy in iframes</a></li>
 	<li><a href="permissions-policy-report-only">Permissions Policy Report-Only</a></li>

--- a/site/pages/index.php
+++ b/site/pages/index.php
@@ -50,7 +50,8 @@ if (\Can\Has\who() !== null) {
 <p>
 	Not all of these use Reporting API, some are proprietary reporting mechanisms and you'll notice them easily &ndash; they don't use the Reporting API's <code>Reporting-Endpoints</code> header.
 	Earlier versions of the Reporting API specification used <code>Report-To</code> header instead of <code>Reporting-Endpoints</code>.
-	The <code>Report-To</code> header is deprecated and should not be confused with the CSP <code>report-to</code> directive.
+	The <code>Report-To</code> header is deprecated and generally shouldn't be used, but it is still required in Chrome to deliver all Network Error Logging reports.
+	It should not be confused with the CSP <code>report-to</code> directive.
 </p>
 
 <h3>Removed Browser Reporting</h3>

--- a/site/pages/intervention.php
+++ b/site/pages/intervention.php
@@ -58,7 +58,7 @@ header($reportingEndpointsHeader);
 		(the above-mentioned <a href="https://www.chromestatus.com/feature/5644273861001216">phone vibrate intervention</a> is not included in this list for some reason).
 	</p>
 
-	<?= \Can\Has\specsHtml('reporting-api'); ?>
+	<?= \Can\Has\specsHtml('reporting-api', 'intervention'); ?>
 </div>
 </div>
 <?= \Can\Has\footerHtml(); ?>

--- a/site/pages/intervention.php
+++ b/site/pages/intervention.php
@@ -20,7 +20,7 @@ header($reportingEndpointsHeader);
 	</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'intervention reports are always delivered to the endpoint named <code>default</code>'); ?>
 
 	<h2>Use an "intervened" feature</h2>
 	<p>

--- a/site/pages/intervention.php
+++ b/site/pages/intervention.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
-header($reportToHeader);
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
+header($reportingEndpointsHeader);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -20,7 +20,7 @@ header($reportToHeader);
 	</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'can be used in a CSP header in the <code>report-to</code> directive, for example'); ?>
 
 	<h2>Use an "intervened" feature</h2>
 	<p>

--- a/site/pages/nel.php
+++ b/site/pages/nel.php
@@ -20,11 +20,17 @@ header($nelHeader);
 		Network Error Logging (NEL) enables web applications to declare a reporting policy that can be used by the browser to report network errors for a given origin.
 		DNS resolution errors, secure connection errors, HTTP errors like 404s, redirect loops etc. But you can even get HTTP 2xx, 3xx success reports, if you wish.
 	</em></p>
+	<p><em>
+		The Network Error Logging specification still uses the now deprecated <code>Report-To</code> header, which was defined in what's sometimes referred to as Reporting API v0.
+		Chrome also sends all NEL reports only when the reporting endpoints are defined with the <code>Report-To</code> header.
+		If you'd use the <code>Reporting-Endpoints</code> header (referred to as Reporting API v1), Chrome would send only some NEL reports, for example the <code>tcp.refused</code> type sent when the server is down, but the report types used here wouldn't be delivered.
+		In the future, NEL <a href="https://github.com/w3c/network-error-logging/issues/159">may use</a> <code>Reporting-Endpoints</code>, or a completely different mechanism to configure the reporting, for <a href="https://github.com/w3c/network-error-logging/issues/173">example DNS records</a>.
+	</em></p>
 	<?= \Can\Has\reportingApiNotSupportedHtml() ?>
 	<h2>The <code>NEL</code> response header:</h2>
 	<pre><code><?= \Can\Has\highlight($nelHeader); ?></code></pre>
 	<ul>
-		<li><code>report_to</code>: name of the group where to send NEL reports (that's an underscore, unlike in the <code>Content-Security-Policy</code> header)</li>
+		<li><code>report_to</code>: name of the group where to send NEL reports, as defined in the <code>Report-To</code> header</li>
 		<li><code>max_age</code>: the lifetime of this NEL policy in seconds, set to weeks or months eventually to also get reports from browsers that have not visited the site for some time</li>
 		<li>
 			<code>include_subdomains</code>: optional, whether this policy applies to all subdomains of the current domain

--- a/site/pages/nel.php
+++ b/site/pages/nel.php
@@ -15,9 +15,9 @@ header($nelHeader);
 <div class="content">
 	<?= \Can\Has\bookmarks('index', 'reports'); ?>
 
-	<h1>Network Error Logging reports</h1>
+	<h1>Network Error Logging (NEL) reports</h1>
 	<p><em>
-		Network Error Logging (NEL) enables web applications to declare a reporting policy that can be used by the browser to report network errors for a given origin.
+		Network Error Logging enables web applications to declare a reporting policy that can be used by the browser to report network errors for a given origin.
 		DNS resolution errors, secure connection errors, HTTP errors like 404s, redirect loops etc. But you can even get HTTP 2xx, 3xx success reports, if you wish.
 	</em></p>
 	<p><em>

--- a/site/pages/nel.php
+++ b/site/pages/nel.php
@@ -24,7 +24,7 @@ header($nelHeader);
 	<h2>The <code>NEL</code> response header:</h2>
 	<pre><code><?= \Can\Has\highlight($nelHeader); ?></code></pre>
 	<ul>
-		<li><code>report_to</code>: name of the group where to send NEL reports to (that's an underscore, unlike in the <code>Content-Security-Policy</code> header)</li>
+		<li><code>report_to</code>: name of the group where to send NEL reports (that's an underscore, unlike in the <code>Content-Security-Policy</code> header)</li>
 		<li><code>max_age</code>: the lifetime of this NEL policy in seconds, set to weeks or months eventually to also get reports from browsers that have not visited the site for some time</li>
 		<li>
 			<code>include_subdomains</code>: optional, whether this policy applies to all subdomains of the current domain

--- a/site/pages/permissions-policy-iframes.php
+++ b/site/pages/permissions-policy-iframes.php
@@ -37,7 +37,7 @@ $iframeUrl = 'https://exploited.cz/frames/fullscreen/fullscreen.html';
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, \Can\Has\permissionsPolicyEndpointNameDescriptionHtml()); ?>
 	<p><em>Note: the <code>Reporting-Endpoints</code> header here is mostly useless as the following violations happen in 3<sup>rd</sup> party embedded iframes, and no reports are sent in such cases.</em></p>
 
 	<h2>Embedded frame cannot go fullscreen</h2>

--- a/site/pages/permissions-policy-iframes.php
+++ b/site/pages/permissions-policy-iframes.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
 $permissionsPolicyHeader = 'Permissions-Policy: fullscreen=(self "https://exploited.cz")';
-header($reportToHeader);
+header($reportingEndpointsHeader);
 header($permissionsPolicyHeader);
 $iframeUrl = 'https://exploited.cz/frames/fullscreen/fullscreen.html';
 ?>
@@ -37,8 +37,8 @@ $iframeUrl = 'https://exploited.cz/frames/fullscreen/fullscreen.html';
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
-	<p><em>Note: the <code>Report-To</code> header here is mostly useless as the following violations happen in 3<sup>rd</sup> party embedded iframes, and no reports are sent in such cases.</em></p>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<p><em>Note: the <code>Reporting-Endpoints</code> header here is mostly useless as the following violations happen in 3<sup>rd</sup> party embedded iframes, and no reports are sent in such cases.</em></p>
 
 	<h2>Embedded frame cannot go fullscreen</h2>
 	<?php \Can\Has\scriptSourceHtmlStart('blocked'); ?>

--- a/site/pages/permissions-policy-report-only.php
+++ b/site/pages/permissions-policy-report-only.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
 $permissionsPolicyHeader = 'Permissions-Policy-Report-Only: fullscreen=()';
-header($reportToHeader);
+header($reportingEndpointsHeader);
 header($permissionsPolicyHeader);
 ?>
 <!DOCTYPE html>
@@ -39,7 +39,7 @@ header($permissionsPolicyHeader);
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
 
 	<h2>Go full screen</h2>
 	<button id="fullscreen" class="allowed">Toggle full screen</button>

--- a/site/pages/permissions-policy-report-only.php
+++ b/site/pages/permissions-policy-report-only.php
@@ -39,7 +39,7 @@ header($permissionsPolicyHeader);
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, \Can\Has\permissionsPolicyEndpointNameDescriptionHtml()); ?>
 
 	<h2>Go full screen</h2>
 	<button id="fullscreen" class="allowed">Toggle full screen</button>

--- a/site/pages/permissions-policy.php
+++ b/site/pages/permissions-policy.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types = 1);
 
-$reportToHeader = \Can\Has\reportToHeader();
+$reportingEndpointsHeader = \Can\Has\reportingEndpointsHeader();
 $permissionsPolicyHeader = 'Permissions-Policy: geolocation=(), fullscreen=(), camera=(self "https://www.michalspacek.com"), midi=*';
-header($reportToHeader);
+header($reportingEndpointsHeader);
 header($permissionsPolicyHeader);
 ?>
 <!DOCTYPE html>
@@ -63,7 +63,7 @@ header($permissionsPolicyHeader);
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportToHeaderHtml($reportToHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
 
 	<h2>Try getting the current location of the device</h2>
 	<button id="geolocation" class="blocked">Get current geolocation</button>

--- a/site/pages/permissions-policy.php
+++ b/site/pages/permissions-policy.php
@@ -25,10 +25,9 @@ header($permissionsPolicyHeader);
 	<p><em>
 		The <code>Permissions-Policy</code> header is similar to Content Security Policy header, although the syntax is different
 			as the <code>Permissions-Policy</code> header is defined as a <a href="https://datatracker.ietf.org/doc/html/rfc8941">Structured Header</a>.
-		Permissions Policy, shipped in Chrome 88, was previously known as Feature Policy and was available in Chrome since 2016. Both Permissions Policy and Feature Policy share the same ideas
+		Permissions Policy, shipped in Chrome 88 in 2021, was previously known as Feature Policy and was available in Chrome since 2016. Both Permissions Policy and Feature Policy share the same ideas
 			but the <code>Feature-Policy</code> header used a <a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#new-header">different format</a>
 			and treated iframe <code>allow</code> attribute <a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#header-and-allow-attribute-combine-differently">differently</a>.
-		The migration is not fully finished yet and the old name still has to be used in scripts.
 	</em></p>
 	<?= \Can\Has\permissionsPolicyFirstPartyReportsHtml(); ?>
 	<?= \Can\Has\reportingApiNotSupportedHtml(); ?>
@@ -63,7 +62,7 @@ header($permissionsPolicyHeader);
 		</li>
 	</ul>
 
-	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, 'the Permissions Policy reports will always be sent to the group named <code>default</code>'); ?>
+	<?= \Can\Has\reportingEndpointsHeaderHtml($reportingEndpointsHeader, \Can\Has\permissionsPolicyEndpointNameDescriptionHtml()); ?>
 
 	<h2>Try getting the current location of the device</h2>
 	<button id="geolocation" class="blocked">Get current geolocation</button>

--- a/site/pages/smtp-tlsrpt.php
+++ b/site/pages/smtp-tlsrpt.php
@@ -22,7 +22,7 @@ declare(strict_types = 1);
 	<pre><code>TXT "v=TLSRPTv1;rua=mailto:example@tlsrpt.report-uri.com"</code></pre>
 	<ul>
 		<li><code>v=TLSRPTv1</code>: this TXT DNS record is a SMTP TLSRPT policy record</li>
-		<li><code>rua</code>: where to send <em>aggregated</em> reports to, can be a <code>mailto:</code> or <code>https:</code> URI (multiple URIs comma-separated)</li>
+		<li><code>rua</code>: where to send <em>aggregated</em> reports, can be a <code>mailto:</code> or <code>https:</code> URI (multiple URIs comma-separated)</li>
 	</ul>
 	<p>
 		The <em>canhas.report</em> domain has no SMTP TLSRPT record because no mail is sent from this domain, which is indicated with

--- a/site/pages/xss-auditor.php
+++ b/site/pages/xss-auditor.php
@@ -26,7 +26,7 @@ header($xxpHeader);
 	<pre><code><?= htmlspecialchars($xxpHeader); ?></code></pre>
 	<ul>
 		<li><code>1</code>: enable the auditor</li>
-		<li><code>report</code>: where to send the reports to</li>
+		<li><code>report</code>: where to send the reports</li>
 	</ul>
 
 	<p>

--- a/site/shared/csp-body.php
+++ b/site/shared/csp-body.php
@@ -27,7 +27,7 @@ declare(strict_types = 1);
 			</ul>
 		</li>
 		<li><code>style-src</code>: allowed CSS sources</li>
-		<li><code><?= htmlspecialchars($reportDirective); ?></code>: <?= htmlspecialchars($reportDirectiveDescription); ?></li>
+		<li><?= $reportDirectiveDescriptionHtml; ?></li>
 	</ul>
 
 	<?= $additionalHeaderHtml; ?>

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -303,6 +303,12 @@ function maxAge(): int
 }
 
 
+function reportToDirectiveDescriptionHtml(): string
+{
+	return '<code>report-to</code>: name of the endpoint where to send violation reports, as defined in the <code>Reporting-Endpoints</code> header';
+}
+
+
 function reportToHeader(): string
 {
 	$reportTo = [
@@ -319,6 +325,12 @@ function reportToHeader(): string
 }
 
 
+function reportingEndpointsHeader(): string
+{
+	return 'Reporting-Endpoints: default="' . reportUrl() . '"';
+}
+
+
 function reportToHeaderHtml(string $header, string $groupDescriptionHtml): string
 {
 	return '<h2>The <code>Report-To</code> response header:</h2>
@@ -330,6 +342,23 @@ function reportToHeaderHtml(string $header, string $groupDescriptionHtml): strin
 				<code>endpoints</code>: reporting endpoint configuration, can specify multiple endpoints but reports will be sent to just one of them
 				<ul>
 					<li><code>url</code>: where to send reports to, must be <code>https://</code>, otherwise the endpoint will be ignored</li>
+				</ul>
+			</li>
+		</ul>';
+}
+
+
+function reportingEndpointsHeaderHtml(string $header, string $endpointNameDescriptionHtml): string
+{
+	return '<h2>The <code>Reporting-Endpoints</code> response header:</h2>
+		<pre><code>' . highlight($header) . '</code></pre>
+		<ul>
+			<li><code>default</code>: the name of the endpoint, ' . $endpointNameDescriptionHtml .  '</li>
+			<li><code>"<em>url</em>"</code>: where to send reports to, must be <code>https://</code>, otherwise the endpoint will be ignored</li>
+			<li>
+				You may provide multiple <code><em>name</em>="<em>url</em>"</code> endpoints separated by comma (<code>,</code>)
+				<ul>
+					<li><small>For example: <code>Reporting-Endpoints: csp-reporting="https://example.com/csp", nel-reporting="https://example.com/nel"</code></small></li>
 				</ul>
 			</li>
 		</ul>';
@@ -415,7 +444,7 @@ function trustedTypesCspHeaderDescriptionHtml(): string
 		<li>
 			<code>report-uri</code>: where to send violation reports to
 			<ul>
-				<li><em>Reporting would also work with the <code>report-to</code> directive, see the <a href="csp-report-to">CSP demo</a>, but let\'s keep things simple here</em></li>
+				<li><small>Reporting would also work with the <code>report-to</code> directive, see the <a href="csp-report-to">CSP demo</a>, but let\'s keep things simple here</small></li>
 			</ul>
 		</li>
 	</ul>';
@@ -534,7 +563,7 @@ function specsHtml(string ...$specs): string
 					<ul>
 						<li><small><a href="https://w3c.github.io/reporting/">Reporting API</a> Editor's Draft (which will evolve into a Working Draft, followed by a Recommendation eventually)</small></li>
 						<li><small>
-							Notable changes in the Editor's Draft are switching to structured headers (<code>Reporting-Endpoints</code> instead of <code>Report-To</code>) and moving out concrete reports into the following separate Draft Community Group Reports:
+							Notable changes in the Editor's Draft are moving out concrete reports into the following separate Draft Community Group Reports:
 							<a href="https://wicg.github.io/crash-reporting/">Crash Reporting</a>,
 							<a href="https://wicg.github.io/deprecation-reporting/">Deprecation Reporting</a>,
 							<a href="https://wicg.github.io/intervention-reporting/">Intervention Reporting</a>

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -562,14 +562,17 @@ function specsHtml(string ...$specs): string
 					<a href="https://www.w3.org/TR/reporting/">Reporting API</a> Working Draft
 					<ul>
 						<li><small><a href="https://w3c.github.io/reporting/">Reporting API</a> Editor's Draft (which will evolve into a Working Draft, followed by a Recommendation eventually)</small></li>
-						<li><small>
-							Notable changes in the Editor's Draft are moving out concrete reports into the following separate Draft Community Group Reports:
-							<a href="https://wicg.github.io/crash-reporting/">Crash Reporting</a>,
-							<a href="https://wicg.github.io/deprecation-reporting/">Deprecation Reporting</a>,
-							<a href="https://wicg.github.io/intervention-reporting/">Intervention Reporting</a>
-						</small></li>
 					</ul>
 				EOT;
+				break;
+			case 'crash':
+				$hrefs[] = '<a href="https://wicg.github.io/crash-reporting/">Crash Reporting</a> Draft Community Group Report';
+				break;
+			case 'deprecation':
+				$hrefs[] = '<a href="https://wicg.github.io/deprecation-reporting/">Deprecation Reporting</a> Draft Community Group Report';
+				break;
+			case 'intervention':
+				$hrefs[] = '<a href="https://wicg.github.io/intervention-reporting/">Intervention Reporting</a> Draft Community Group Report';
 				break;
 			case 'nel':
 				$hrefs[] = '<a href="https://www.w3.org/TR/network-error-logging/">Network Error Logging</a> Working Draft';

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -466,6 +466,20 @@ function permissionsPolicyNotSupportedHtml(string $messageSuffix = 'all features
 }
 
 
+function permissionsPolicyEndpointNameDescriptionHtml(): string
+{
+	return <<< 'EOT'
+		the Permissions Policy reports will be sent to the endpoint named <code>default</code>;
+		to send policy violation reports to a different endpoint, you have to specify it for each feature with a <code>report-to</code> parameter
+		<ul>
+			<li><small>For example: <code>Permissions-Policy: geolocation=();report-to=geo-reporting, fullscreen=();report-to=fs-reporting</code></small></li>
+			<li><small>Then add <code>geo-reporting=<em>"url"</em></code> and <code>fs-reporting=<em>"url"</em></code> endpoints to your <code>Reporting-Endpoints</code> header</small></li>
+			<li><small>Endpoint names in all <code>report-to</code> directives can be the same, but you can't change the reporting endpoint for all features at once</small></li>
+		</ul>
+	EOT;
+}
+
+
 function scriptSourceHtmlStart(string $class): bool
 {
 	static $counter = 0;
@@ -619,6 +633,7 @@ function specsHtml(string ...$specs): string
 					</ul>
 				EOT;
 				$hrefs[] = '<a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md">Permissions Policy explainer</a>';
+				$hrefs[] = '<a href="https://github.com/w3c/webappsec-permissions-policy/blob/main/reporting.md">Permissions Policy reporting details</a>';
 				break;
 		}
 	}

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -354,7 +354,7 @@ function reportingEndpointsHeaderHtml(string $header, string $endpointNameDescri
 		<pre><code>' . highlight($header) . '</code></pre>
 		<ul>
 			<li><code>default</code>: the name of the endpoint, ' . $endpointNameDescriptionHtml .  '</li>
-			<li><code>"<em>url</em>"</code>: where to send reports to, must be <code>https://</code>, otherwise the endpoint will be ignored</li>
+			<li><code>"<em>url</em>"</code>: where to send reports, must be <code>https://</code>, otherwise the endpoint will be ignored</li>
 			<li>
 				You may provide multiple <code><em>name</em>="<em>url</em>"</code> endpoints separated by comma (<code>,</code>)
 				<ul>
@@ -442,7 +442,7 @@ function trustedTypesCspHeaderDescriptionHtml(): string
 			<code>' . highlight("require-trusted-types-for 'script'") . '</code>: enable Trusted Types for <abbr title="Document Object Model">DOM</abbr> <abbr title="Cross-Site Scripting">XSS</abbr> sinks (<code>' . highlight("'script'") . '</code> is the only available value)
 		</li>
 		<li>
-			<code>report-uri</code>: where to send violation reports to
+			<code>report-uri</code>: where to send violation reports
 			<ul>
 				<li><small>Reporting would also work with the <code>report-to</code> directive, see the <a href="csp-report-to">CSP demo</a>, but let\'s keep things simple here</small></li>
 			</ul>

--- a/site/shared/functions.php
+++ b/site/shared/functions.php
@@ -400,7 +400,7 @@ function willTriggerReportUriHtml(): string
 
 function willTriggerReportToHtml(string $what = 'violation'): string
 {
-	return "Will trigger a report that will be sent asynchronously, possibly grouped with other reports ({$what} visible in Developer Tools in the <em>Console</em> tab, you won't see the report in <em>Network</em> tab but you can still"
+	return "Will trigger a report that will be sent asynchronously ({$what} visible in Developer Tools in the <em>Console</em> tab, you won't see the report in <em>Network</em> tab but you can still"
 		. ' <a href="https://www.michalspacek.com/chrome-err_spdy_protocol_error-and-an-invalid-http-header#chrome-71-and-newer">view the reporting requests</a>)';
 }
 


### PR DESCRIPTION
Switch demos to use `Reporting-Endpoints` header, not `Report-To`, except for NEL as it doesn't support Reporting API v1 (`Reporting-Endpoints`) both in the spec, and in Chrome, which doesn't send all NEL reports with `Reporting-Endpoints`. It does send some (like `tcp.refused` when the site goes down), but not DNS errors and 404s used in the NEL demo here.

So NEL reporting should still uses Reporting API v0 (`Report-To`), see also https://developer.chrome.com/blog/reporting-api-migration#network_error_logging

Close #21
Close #39
